### PR TITLE
fix: move typescript to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Naive EBNF LL Autocompletion parser.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [ 
+  "files": [
       "dist",
       "!dist/**/launch.*"
   ],
@@ -14,14 +14,14 @@
     "url": "https://github.com/kareltucek/naive-autocompletion-parser"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
-    "typescript": "^5.3.3"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",
     "@types/lodash": "^4.14.202",
     "@types/prompt-sync": "^4.2.3",
-    "prompt-sync": "^4.2.0"
+    "prompt-sync": "^4.2.0",
+    "typescript": "^5.3.3"
   },
   "author": "Karel Tuček",
   "license": "MIT"


### PR DESCRIPTION
Typescript not used in the published npm package